### PR TITLE
Add modalTariff state and pass to EducationPopup

### DIFF
--- a/src/components/EducationPopup/EducationPopup.tsx
+++ b/src/components/EducationPopup/EducationPopup.tsx
@@ -15,10 +15,12 @@ export function EducationPopup({
   translation,
   locale,
   onClose,
+  modalTariff,
 }: {
   translation: Record<string, unknown>;
   locale: string;
   onClose: () => void;
+  modalTariff: string;
 }) {
   const [visible, setVisible] = useState(false);
   const popupRef = useRef<HTMLDivElement>(null);
@@ -32,6 +34,8 @@ export function EducationPopup({
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const isValid = fullName.trim() && phone.trim() && email.trim();
+
+  console.log(modalTariff);
 
   const validateValue = (name: string, value: string) => {
     let error = "";
@@ -113,10 +117,13 @@ export function EducationPopup({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    
+
     const payload = {
       full_name: fullName,
       phone,
       email,
+      tariff_type: modalTariff,
     };
 
     const localErrors = validateForm(

--- a/src/components/EducationTariffs/EducationTariffs.tsx
+++ b/src/components/EducationTariffs/EducationTariffs.tsx
@@ -93,7 +93,7 @@ export const EducationTariffs = () => {
             <span>{t('tariff_price')}:</span>
             <span>{tariff.price}</span>
           </div>
-          <button onClick={() => openModal("formB")}>{tariff.buttonText}</button>
+          <button onClick={() => openModal("formB", tariff.title)}>{tariff.buttonText}</button>
         </div>
       ))}
     </div>

--- a/src/components/ModalContext.tsx
+++ b/src/components/ModalContext.tsx
@@ -32,10 +32,15 @@ export const ModalProvider = ({
 }) => {
   const [currentModal, setCurrentModal] = useState<ModalKey>(null);
   const [modalPayload, setModalPayload] = useState<string>("");
+  const [modalTariff, setModalTariff] = useState<string>("");
   const openModal = (key: ModalKey, payload?: string) => {
     setCurrentModal(key);
     if (payload) {
       setModalPayload(payload);
+    }
+
+    if (key === "formB") {
+      setModalTariff(payload || "");
     }
   };
   const closeModal = () => {
@@ -58,6 +63,7 @@ export const ModalProvider = ({
           onClose={closeModal}
           translation={translation}
           locale={locale}
+          modalTariff={modalTariff}
         />
       )}
       {currentModal === "formC" && (


### PR DESCRIPTION
- Introduced modalTariff state in ModalContext to manage tariff data for modals.
- Updated openModal function to set modalTariff when opening formB.
- Modified EducationPopup to accept modalTariff as a prop and include it in the form submission payload.
- Adjusted button in EducationTariffs to pass tariff title as payload when opening formB.